### PR TITLE
add GreaadSolver implementation

### DIFF
--- a/src/main/scala/Chainsaw/ChainsawBaseGenerator.scala
+++ b/src/main/scala/Chainsaw/ChainsawBaseGenerator.scala
@@ -24,9 +24,9 @@ trait ChainsawBaseGenerator {
 
   def outputTypes: Seq[NumericType]
 
-  /** --------
-   * model
-   * -------- */
+  /** -------- model
+    * --------
+    */
   def impl(testCase: TestCase): Seq[BigDecimal]
 
   def metric(yours: Seq[BigDecimal], golden: Seq[BigDecimal]): Boolean
@@ -35,9 +35,9 @@ trait ChainsawBaseGenerator {
 
   def resetCycle: Int
 
-  /** --------
-   * implementations
-   * -------- */
+  /** -------- implementations
+    * --------
+    */
   def simBackEnd: SpinalSimBackendSel = SpinalSimBackendSel.VERILATOR
 
   def implH: ChainsawBaseModule // core module, that is, the datapath
@@ -59,11 +59,11 @@ trait ChainsawBaseGenerator {
 
     def getNaive: ChainsawBaseModule =
       if (!atSimTime) implPass
-      else implNaiveH match {
-        case Some(impl) => impl
-        case None => throw new IllegalArgumentException("no naive implementation found")
-      }
-
+      else
+        implNaiveH match {
+          case Some(impl) => impl
+          case None       => throw new IllegalArgumentException("no naive implementation found")
+        }
 
     if (useNaive) getNaive
     else {
@@ -79,9 +79,9 @@ trait ChainsawBaseGenerator {
 
   def outPortWidth = outputTypes.length
 
-  /** --------
-   * utils for input/output generation
-   * -------- */
+  /** -------- utils for input/output generation
+    * --------
+    */
 
   def emptyTypes: Seq[NumericType] = Seq[NumericType]()
 
@@ -93,9 +93,9 @@ trait ChainsawBaseGenerator {
 
   def randomTestCase: TestCase
 
-  /** --------
-   * utils for test
-   * -------- */
+  /** -------- utils for test
+    * --------
+    */
 
   def doSelfTest() = ChainsawTest(s"test$name", this)
 
@@ -108,9 +108,9 @@ trait ChainsawBaseGenerator {
        |fmaxEstimated: ${fmaxEstimation / 1e6} MHz
        |""".stripMargin
 
-  /** --------
-   * utils for instantiation
-   * -------- */
+  /** -------- utils for instantiation
+    * --------
+    */
   def process(data: Seq[AFix]) = {
     val core = implH
     core.dataIn.zip(data).foreach { case (in, data) => in := data }
@@ -188,7 +188,7 @@ trait ChainsawDynamicOperatorGenerator extends ChainsawBaseGenerator with Operat
   override def randomTestCase = TestCase(randomDataVector, randomControlVector)
 }
 
-trait ChainsawFrameGenerator extends ChainsawBaseGenerator with FixedLatency with Frame {
+trait ChainsawFrameGenerator extends ChainsawBaseGenerator with Frame with FixedLatency {
 
   def inputFrameFormat: FrameFormat
 
@@ -239,7 +239,7 @@ trait ChainsawDynamicFrameGenerator extends ChainsawBaseGenerator with Frame wit
   }
 }
 
-trait ChainsawInfiniteGenerator extends ChainsawBaseGenerator with FixedLatency with SemiInfinite {
+trait ChainsawInfiniteGenerator extends ChainsawBaseGenerator with SemiInfinite with FixedLatency {
 
   override def implH: ChainsawInfiniteModule
 
@@ -252,7 +252,7 @@ trait ChainsawInfiniteGenerator extends ChainsawBaseGenerator with FixedLatency 
   override def randomTestCase = TestCase(Seq.fill(resetCycle)(randomDataVector).flatten)
 }
 
-trait ChainsawDynamicInfiniteGenerator extends ChainsawBaseGenerator with Dynamic with SemiInfinite {
+trait ChainsawDynamicInfiniteGenerator extends ChainsawBaseGenerator with SemiInfinite with Dynamic {
 
   override def implH: ChainsawDynamicInfiniteModule
 
@@ -264,7 +264,6 @@ trait ChainsawDynamicInfiniteGenerator extends ChainsawBaseGenerator with Dynami
 
   override def randomTestCase = TestCase(Seq.fill(resetCycle)(randomDataVector).flatten, randomControlVector)
 }
-
 
 trait Unaligned {
   def inputTimes: Seq[Int]

--- a/src/main/scala/Chainsaw/Enums.scala
+++ b/src/main/scala/Chainsaw/Enums.scala
@@ -112,6 +112,7 @@ object BITGEN extends EdaFlowType // generate bitstream
 
 sealed trait CompressionStrategy extends ChainsawEnum
 
-object EfficiencyFirst extends CompressionStrategy
-
-object ReductionFirst extends CompressionStrategy
+// ReductionEfficiency First
+object ReFirst extends CompressionStrategy
+// HeightReduction First
+object HrFirst extends CompressionStrategy

--- a/src/main/scala/Chainsaw/arithmetic/BmAlgo.scala
+++ b/src/main/scala/Chainsaw/arithmetic/BmAlgo.scala
@@ -6,9 +6,8 @@ import Chainsaw.xilinx.VivadoUtilEstimation
 import scala.util.Random
 
 /** long multiplication implemented by divide-and-conquer
- */
-class BmAlgo(val bmSolution: BmSolution)
-  extends HardAlgo with MultAttribute {
+  */
+class BmAlgo(val bmSolution: BmSolution) extends HardAlgo with MultAttribute {
 
   // more accurate concept for clbCost
 
@@ -27,12 +26,11 @@ class BmAlgo(val bmSolution: BmSolution)
     if (multiplierType == MsbMultiplier || multiplierType == LsbMultiplier) bmSolution.widthFull
     else bmSolution.widthOut
 
-
-  /** --------
-   * cost statistics
-   * -------- */
-  var multCost = 0
-  var fixCost = 0
+  /** -------- cost statistics
+    * --------
+    */
+  var multCost  = 0
+  var fixCost   = 0
   var splitCost = 0
   var mergeCost = 0
   var cmultCost = 0
@@ -44,34 +42,35 @@ class BmAlgo(val bmSolution: BmSolution)
   val dspLatency = 2
   val andLatency = 1
 
-  /** --------
-   * operations in BmAlgo
-   * -------- */
-  def splitN(x: WeightedValue, n: Int): Seq[WeightedValue] = {
+  /** -------- operations in BmAlgo
+    * --------
+    */
+  def splitN(x: WeightedBigInt, n: Int): Seq[WeightedBigInt] = {
     val paddedWidth = x.arithInfo.width.nextMultipleOf(n)
-    val values = x.value.toBitValue(paddedWidth).splitN(n)
-    values.zip(x.arithInfo.splitN(n))
-      .map { case (value, arithInfo) => WeightedValue(value, arithInfo) }
+    val values      = x.value.toBitValue(paddedWidth).splitN(n)
+    values
+      .zip(x.arithInfo.splitN(n))
+      .map { case (value, arithInfo) => WeightedBigInt(value, arithInfo) }
   }
 
-  def splitMSB(x: WeightedValue) = {
-    val (msb, main) = x.value.toBitValue(x.arithInfo.width).splitAt(x.arithInfo.width - 1)
+  def splitMSB(x: WeightedBigInt) = {
+    val (msb, main)                   = x.value.toBitValue(x.arithInfo.width).splitAt(x.arithInfo.width - 1)
     val (msbArithInfo, mainArithInfo) = x.arithInfo.splitMsb
-    (WeightedValue(msb, msbArithInfo), WeightedValue(main, mainArithInfo))
+    (WeightedBigInt(msb, msbArithInfo), WeightedBigInt(main, mainArithInfo))
   }
 
-  def add(v0: WeightedValue, v1: WeightedValue, constant: Boolean = false) = {
+  def add(v0: WeightedBigInt, v1: WeightedBigInt, constant: Boolean = false) = {
     require(v0.arithInfo.width == v1.arithInfo.width, s"v0: ${v0.arithInfo}, v1: ${v1.arithInfo}")
     if (!constant) splitCost += v0.arithInfo.width
-    WeightedValue(value = v0.value + v1.value, arithInfo = v0.arithInfo + v1.arithInfo)
+    WeightedBigInt(value = v0.value + v1.value, arithInfo = v0.arithInfo + v1.arithInfo)
   }
 
-  def mult(v0: WeightedValue, v1: WeightedValue) = {
+  def mult(v0: WeightedBigInt, v1: WeightedBigInt) = {
     require(v0.arithInfo.isPositive == v1.arithInfo.isPositive)
     require(v0.arithInfo.time == v1.arithInfo.time)
 
     val constantWeight = if (isConstantMult) Csd(v1.value).weight else v1.arithInfo.width
-    val useCMult = isConstantMult && constantWeight < bmSolution.threshold
+    val useCMult       = isConstantMult && constantWeight < bmSolution.threshold
     if (useCMult) {
       cmultCost += bmSolution.dspSize._1 * (constantWeight - 1) // TODO: more accurate estimation
     } else {
@@ -79,117 +78,130 @@ class BmAlgo(val bmSolution: BmSolution)
       fixCost += bmSolution.baseMultiplier.clbCost
     }
 
-    WeightedValue(value = v0.value * v1.value, arithInfo = v0.arithInfo * v1.arithInfo)
+    WeightedBigInt(value = v0.value * v1.value, arithInfo = v0.arithInfo * v1.arithInfo)
   }
 
-  def and(v0: WeightedValue, v1: WeightedValue) = {
-    WeightedValue(value = v0.value * v1.value, arithInfo = v0.arithInfo & v1.arithInfo)
+  def and(v0: WeightedBigInt, v1: WeightedBigInt) = {
+    WeightedBigInt(value = v0.value * v1.value, arithInfo = v0.arithInfo & v1.arithInfo)
   }
 
-  def merge(weightedValues: Seq[WeightedValue], widthOut: Int): WeightedValue = {
-    val base = weightedValues.map(_.arithInfo.weight).min
-    mergeCost += (weightedValues.map(_.arithInfo.width).sum - widthOut)
-    val value = weightedValues.map(_.eval).sum >> base
-    WeightedValue(value = value,
-      arithInfo = weightedValues.head.arithInfo.mergeWith(weightedValues.tail.map(_.arithInfo), widthOut))
+  def merge(WeightedBigInts: Seq[WeightedBigInt], widthOut: Int): WeightedBigInt = {
+    val base = WeightedBigInts.map(_.arithInfo.weight).min
+    mergeCost += (WeightedBigInts.map(_.arithInfo.width).sum - widthOut)
+    val value = WeightedBigInts.map(_.eval).sum >> base
+    WeightedBigInt(value = value, arithInfo = WeightedBigInts.head.arithInfo.mergeWith(WeightedBigInts.tail.map(_.arithInfo), widthOut))
   }
 
-  /** --------
-   * algorithm
-   * -------- */
-  def doRectangular(x: WeightedValue, y: WeightedValue, bmSolution: BmSolution): WeightedValue = {
+  /** -------- algorithm
+    * --------
+    */
+  def doRectangular(x: WeightedBigInt, y: WeightedBigInt, bmSolution: BmSolution): WeightedBigInt = {
 
     if (bmSolution.isEmpty) {
-      if (x.arithInfo.weight + y.arithInfo.weight < weightMax) mult(x, y) else WeightedValue(0, ArithInfo(0, x.arithInfo.weight + y.arithInfo.weight))
-    }
-    else {
+      if (x.arithInfo.weight + y.arithInfo.weight < weightMax) mult(x, y) else WeightedBigInt(0, ArithInfo(0, x.arithInfo.weight + y.arithInfo.weight))
+    } else {
 
-      val current = bmSolution.topDecomposition
-      val currentType = current.multiplierType
+      val current         = bmSolution.topDecomposition
+      val currentType     = current.multiplierType
       val currentWidthOut = current.widthOut
       import current._
-
 
       val aWords = splitN(x, aSplit) // width = baseHeight
       val bWords = splitN(y, bSplit) // width = baseWidth
 
-      def doNSplit(aWords: Seq[WeightedValue], bWords: Seq[WeightedValue]): Seq[WeightedValue] = {
+      def doNSplit(aWords: Seq[WeightedBigInt], bWords: Seq[WeightedBigInt]): Seq[WeightedBigInt] = {
 
         currentType match {
           case FullMultiplier =>
             if (isKara) {
-              val diagonals: Seq[WeightedValue] = (0 until split).map { i =>
+              val diagonals: Seq[WeightedBigInt] = (0 until split).map { i =>
                 doRectangular(aWords(i), bWords(i), bmSolution.subSolution(bmSolution.multiplierType))
               }
 
-              val prods: Seq[WeightedValue] = Seq.tabulate(split, split) { (i, j) =>
-                if (i > j) { // upper triangular, generated by karatsuba method
-                  // pre-addition
-                  val weight = aWords(i).arithInfo.weight + bWords(j).arithInfo.weight
-                  require(aWords(i).arithInfo.weight + bWords(j).arithInfo.weight == aWords(j).arithInfo.weight + bWords(i).arithInfo.weight)
-                  val combinedA = add(aWords(i), aWords(j))
-                  val combinedB = add(bWords(i), bWords(j), isConstantMult)
-                  val (aMsb, aMain) = splitMSB(combinedA)
-                  val (bMsb, bMain) = splitMSB(combinedB)
-                  // sub-multiplication
-                  val full = doRectangular(aMain, bMain, bmSolution.subSolution(FullMultiplier)).withWeight(weight)
-                  val high = -diagonals(i).withWeight(weight)
-                  val low = -diagonals(j).withWeight(weight)
-                  // full - high - low
-                  val mainSegments = Seq(full, high, low)
-                  // side-multiplications
-                  val sideA = and(bMain, aMsb).withWeight(weight + baseHeight)
-                  val sideB = and(aMain, bMsb).withWeight(weight + baseWidth)
-                  val ab = and(aMsb, bMsb).withWeight(weight + baseWidth + baseHeight)
-                  val sideSegments = Seq(sideA, sideB, ab)
-                  Some(mainSegments ++ sideSegments)
-                } else None
-              }.flatten.flatten.flatten
+              val prods: Seq[WeightedBigInt] = Seq
+                .tabulate(split, split) { (i, j) =>
+                  if (i > j) { // upper triangular, generated by karatsuba method
+                    // pre-addition
+                    val weight = aWords(i).arithInfo.weight + bWords(j).arithInfo.weight
+                    require(aWords(i).arithInfo.weight + bWords(j).arithInfo.weight == aWords(j).arithInfo.weight + bWords(i).arithInfo.weight)
+                    val combinedA     = add(aWords(i), aWords(j))
+                    val combinedB     = add(bWords(i), bWords(j), isConstantMult)
+                    val (aMsb, aMain) = splitMSB(combinedA)
+                    val (bMsb, bMain) = splitMSB(combinedB)
+                    // sub-multiplication
+                    val full = doRectangular(aMain, bMain, bmSolution.subSolution(FullMultiplier)).withWeight(weight)
+                    val high = -diagonals(i).withWeight(weight)
+                    val low  = -diagonals(j).withWeight(weight)
+                    // full - high - low
+                    val mainSegments = Seq(full, high, low)
+                    // side-multiplications
+                    val sideA        = and(bMain, aMsb).withWeight(weight + baseHeight)
+                    val sideB        = and(aMain, bMsb).withWeight(weight + baseWidth)
+                    val ab           = and(aMsb, bMsb).withWeight(weight + baseWidth + baseHeight)
+                    val sideSegments = Seq(sideA, sideB, ab)
+                    Some(mainSegments ++ sideSegments)
+                  } else None
+                }
+                .flatten
+                .flatten
+                .flatten
               diagonals ++ prods
             } else {
-              Seq.tabulate(split, split) { (i, j) =>
-                doRectangular(aWords(i), bWords(j), bmSolution.subSolution(bmSolution.multiplierType))
-              }.flatten
+              Seq
+                .tabulate(split, split) { (i, j) =>
+                  doRectangular(aWords(i), bWords(j), bmSolution.subSolution(bmSolution.multiplierType))
+                }
+                .flatten
             }
 
           case SquareMultiplier =>
-            Seq.tabulate(split, split) { (i, j) =>
-              if (i >= j) { // upper triangular
-                val multType = if (i == j) bmSolution.multiplierType else FullMultiplier
-                val prod = doRectangular(aWords(i), bWords(j), bmSolution.subSolution(multType))
-                val ret = if (i != j) prod << 1 else prod
-                Some(ret)
-              } else None
-            }.flatten.flatten
+            Seq
+              .tabulate(split, split) { (i, j) =>
+                if (i >= j) { // upper triangular
+                  val multType = if (i == j) bmSolution.multiplierType else FullMultiplier
+                  val prod     = doRectangular(aWords(i), bWords(j), bmSolution.subSolution(multType))
+                  val ret      = if (i != j) prod << 1 else prod
+                  Some(ret)
+                } else None
+              }
+              .flatten
+              .flatten
 
           case MsbMultiplier =>
-            Seq.tabulate(split, split) { (i, j) =>
-              if (i + j >= split - 1) {
-                val multType = if (i + j == split - 1) bmSolution.multiplierType else FullMultiplier
-                val ret = doRectangular(aWords(i), bWords(j), bmSolution.subSolution(multType))
-                Some(ret)
+            Seq
+              .tabulate(split, split) { (i, j) =>
+                if (i + j >= split - 1) {
+                  val multType = if (i + j == split - 1) bmSolution.multiplierType else FullMultiplier
+                  val ret      = doRectangular(aWords(i), bWords(j), bmSolution.subSolution(multType))
+                  Some(ret)
+                } else None
               }
-              else None
-            }.flatten.flatten
+              .flatten
+              .flatten
 
           case LsbMultiplier =>
-            Seq.tabulate(split, split) { (i, j) =>
-              if (i + j <= split - 1) {
-                val multType = if (i + j == split - 1) bmSolution.multiplierType else FullMultiplier
-                val ret = doRectangular(aWords(i), bWords(j), bmSolution.subSolution(multType))
-                Some(ret)
+            Seq
+              .tabulate(split, split) { (i, j) =>
+                if (i + j <= split - 1) {
+                  val multType = if (i + j == split - 1) bmSolution.multiplierType else FullMultiplier
+                  val ret      = doRectangular(aWords(i), bWords(j), bmSolution.subSolution(multType))
+                  Some(ret)
+                } else None
               }
-              else None
-            }.flatten.flatten
+              .flatten
+              .flatten
         }
       }
 
-      val segments = Seq.tabulate(factorB, factorA) { (i, j) => // for rectangular
-        // distribute words to N-split sub modules
-        val as = aWords.zipWithIndex.filter(_._2 % factorB == i).map(_._1)
-        val bs = bWords.zipWithIndex.filter(_._2 % factorA == j).map(_._1)
-        doNSplit(as, bs)
-      }.flatten.flatten
+      val segments = Seq
+        .tabulate(factorB, factorA) { (i, j) => // for rectangular
+          // distribute words to N-split sub modules
+          val as = aWords.zipWithIndex.filter(_._2 % factorB == i).map(_._1)
+          val bs = bWords.zipWithIndex.filter(_._2 % factorA == j).map(_._1)
+          doNSplit(as, bs)
+        }
+        .flatten
+        .flatten
 
       val validSegments = segments.filter(_.arithInfo.weight < weightMax)
       assert(validSegments.forall(_.arithInfo.width != 0))
@@ -198,27 +210,24 @@ class BmAlgo(val bmSolution: BmSolution)
     }
   }
 
-  /** --------
-   * entrance to algorithm
-   * -------- */
+  /** -------- entrance to algorithm
+    * --------
+    */
   def impl(x: BigInt, y: BigInt, verbose: Boolean = false): BigInt = {
 
     def adjustForMultType(value: BigInt) = {
       bmSolution.multiplierType match {
         case MsbMultiplier => value >> bmSolution.widthFull
         case LsbMultiplier => value.mod(Pow2(bmSolution.widthFull))
-        case _ => value
+        case _             => value
       }
     }
 
-    val yInUse = if (isConstantMult) bmSolution.constant.get else if (bmSolution.multiplierType == SquareMultiplier) x else y
+    val yInUse     = if (isConstantMult) bmSolution.constant.get else if (bmSolution.multiplierType == SquareMultiplier) x else y
     val tempGolden = x * yInUse
-    val tempRet = doRectangular(
-      WeightedValue(x, ArithInfo(bmSolution.widthFull, 0)),
-      WeightedValue(yInUse, ArithInfo(bmSolution.widthFull, 0)),
-      bmSolution).eval
-    val golden = adjustForMultType(tempGolden)
-    val ret = adjustForMultType(tempRet)
+    val tempRet    = doRectangular(WeightedBigInt(x, ArithInfo(bmSolution.widthFull, 0)), WeightedBigInt(yInUse, ArithInfo(bmSolution.widthFull, 0)), bmSolution).eval
+    val golden     = adjustForMultType(tempGolden)
+    val ret        = adjustForMultType(tempRet)
 
     if (verbose) {
       val multName = s"${bmSolution.widthFull}-bit ${if (isConstantMult) "constant" else "variable"} ${className(bmSolution.multiplierType)} threshold = ${bmSolution.threshold}"
@@ -243,15 +252,16 @@ class BmAlgo(val bmSolution: BmSolution)
   def selfTest(): Unit = {
     def getMultiplicand = BigInt(bmSolution.widthFull, Random)
 
-    val data = if (bmSolution.multiplierType == SquareMultiplier) Seq.fill(1000)(getMultiplicand).map(x => (x, x))
-    else Seq.fill(1000)(getMultiplicand, getMultiplicand)
+    val data =
+      if (bmSolution.multiplierType == SquareMultiplier) Seq.fill(1000)(getMultiplicand).map(x => (x, x))
+      else Seq.fill(1000)(getMultiplicand, getMultiplicand)
     data.foreach { case (x, y) => impl(x, y) }
     logger.info("bm algo test passed")
   }
 
-  /** --------
-   * determine cost while initializing
-   * -------- */
+  /** -------- determine cost while initializing
+    * --------
+    */
   impl(BigInt(bmSolution.widthFull, Random), BigInt(bmSolution.widthFull, Random))
   val eff = 1.0 // TODO: vary for different sizes
 

--- a/src/main/scala/Chainsaw/arithmetic/Gpcs.scala
+++ b/src/main/scala/Chainsaw/arithmetic/Gpcs.scala
@@ -46,7 +46,7 @@ abstract class Gpc extends CompressorGenerator {
     val paddedBitsIn = bitsIn.zip(inputFormat).map { case (bits, h) => bits.padTo(h, False) }
     // in GPCs, different from row adders, we use columns as operands
     val operands = paddedBitsIn.map(_.asBits().asUInt.toAFix)
-    val core = getImplH
+    val core     = getImplH
     core.dataIn := operands
     operands2Columns(core.dataOut, outputFormat).asInstanceOf[BitHeapHard]
   }
@@ -68,8 +68,7 @@ abstract class Gpc extends CompressorGenerator {
 }
 
 /** -------- from flopoco, clbCost = 0.5 --------
- *
- */
+  */
 class HalfClbGpc(override val inputFormat: Seq[Int]) extends Gpc {
 
   override def outputFormat = Seq.fill(5)(1)
@@ -80,9 +79,7 @@ class HalfClbGpc(override val inputFormat: Seq[Int]) extends Gpc {
   override def implH: ChainsawOperatorModule = ???
 }
 
-class PrimitiveGpc(override val inputFormat: Seq[Int],
-                   override val outputFormat: Seq[Int],
-                   primitive: GpcPrimitive, utilEstimation: VivadoUtil) extends Gpc {
+class PrimitiveGpc(override val inputFormat: Seq[Int], override val outputFormat: Seq[Int], primitive: GpcPrimitive, utilEstimation: VivadoUtil) extends Gpc {
 
   override def implH: ChainsawOperatorModule = new ChainsawOperatorModule(this) {
     dataOut := primitive.primitiveCompress(dataIn)
@@ -118,17 +115,17 @@ object Compressor3to2 extends PrimitiveGpc(Seq(3), Seq(1, 1), Compressor3to2Prim
 
 object Gpcs {
 
-  def apply(): Seq[Seq[Gpc]] = Seq(
-    Seq(Compressor6to3),
-    Seq(Compressor3to2),
-    Seq(Compressor606),
-    Seq(Compressor607),
-    Seq(Compressor615),
-    Seq(Compressor623),
-    Seq(Compressor1325),
-    Seq(Compressor1415),
-    Seq(Compressor1406),
-    Seq(Compressor1407),
-    Seq(Compressor2117)
+  def apply(): Seq[Gpc] = Seq(
+    Compressor6to3,
+    Compressor3to2
+//    Compressor606,
+//    Compressor607,
+//    Compressor615,
+//    Compressor623,
+//    Compressor1325,
+//    Compressor1415,
+//    Compressor1406,
+//    Compressor1407,
+//    Compressor2117
   )
 }

--- a/src/main/scala/Chainsaw/arithmetic/bitheap/BitHeapCompressor.scala
+++ b/src/main/scala/Chainsaw/arithmetic/bitheap/BitHeapCompressor.scala
@@ -8,33 +8,33 @@ import java.io.File
 import scala.language.postfixOps
 
 /** enhanced multi-operand adder implemented by compressors
- */
-case class BitHeapCompressor(arithInfos: Seq[ArithInfo], solver: BitHeapSolver = NaiveSolver)
-  extends UnsignedMerge {
+  */
+case class BitHeapCompressor(arithInfos: Seq[ArithInfo], solver: BitHeapSolver = NaiveSolver) extends UnsignedMerge {
 
-  override def name = s"BitHeapCompressor_${hashName(arithInfos)}"
+  override def name = s"BitHeapCompressor_${hashName(arithInfos)}_${solver.solverName}"
 
   val bitHeapGroup = BitHeapGroup.fromInfos(arithInfos.map(_.toPositive))
   if (compensation > BigInt(0)) bitHeapGroup.addNegativeConstant(-compensation)
 
   val solutionFile = new File(compressorSolutionDir, s"$name")
-  val solution = if (solutionFile.exists()) CompressorFullSolution.load(solutionFile)
-  else {
-    val solution = solver.solveAll(bitHeapGroup)
-    solution.save(solutionFile)
-    solution
-  }
+  val solution =
+    if (solutionFile.exists()) CompressorFullSolution.load(solutionFile)
+    else {
+      val solution = solver.solveAll(bitHeapGroup)
+      solution.save(solutionFile)
+      solution
+    }
   logger.info(s"solution cost = ${solution.vivadoUtilEstimation}")
 
-  override def outputTypes = Seq.fill(3)(NumericType.U(maxValue.bitLength))
+  override def outputTypes = Seq.fill(solution.outHeight)(NumericType.U(maxValue.bitLength))
 
   override def latency() = solution.latency()
 
   override def implH = new ChainsawOperatorModule(this) {
     // FIXME: ~ operation should be used outside the bitHeapCompressor
-    val operands = dataIn.zip(arithInfos).map { case (fix, info) => if (info.isPositive) fix.asUInt() else ~fix.asUInt() }
+    val operands      = dataIn.zip(arithInfos).map { case (fix, info) => if (info.isPositive) fix.asUInt() else ~fix.asUInt() }
     val weightedUInts = operands.zip(arithInfos).map { case (int, info) => WeightedUInt(int, info.toPositive) }
-    val bitHeapGroup = BitHeapGroup.fromUInts(weightedUInts)
+    val bitHeapGroup  = BitHeapGroup.fromUInts(weightedUInts)
     if (compensation > BigInt(0)) bitHeapGroup.addNegativeConstant(-compensation)
     dataOut := bitHeapGroup.implAllHard(solution).toUInts.map(_.resize(validLength)).map(_.toAFix)
   }

--- a/src/main/scala/Chainsaw/arithmetic/bitheap/BitHeapGroup.scala
+++ b/src/main/scala/Chainsaw/arithmetic/bitheap/BitHeapGroup.scala
@@ -8,7 +8,6 @@ import scala.collection.mutable.ArrayBuffer
 import scala.language.postfixOps
 import scala.math._
 
-
 case class BitHeapGroup[T](bitHeaps: ArrayBuffer[BitHeap[T]]) {
 
   require(bitHeaps.map(_.time).distinct.length == bitHeaps.length, "all BitHeap must have different time value")
@@ -19,9 +18,9 @@ case class BitHeapGroup[T](bitHeaps: ArrayBuffer[BitHeap[T]]) {
 
   def precision = Pow2(weightLow)
 
-  /** --------
-   * modifications
-   * -------- */
+  /** -------- modifications
+    * --------
+    */
 
   private def representable(value: BigInt) = value.mod(precision) == 0
 
@@ -29,7 +28,7 @@ case class BitHeapGroup[T](bitHeaps: ArrayBuffer[BitHeap[T]]) {
     require(constant < 0 && representable(-constant))
     require(maxValue >= -constant, "meaningless to add a negative constant larger than the max value")
     val validLength = (maxValue + constant).bitLength
-    val complement = Pow2(validLength) + constant
+    val complement  = Pow2(validLength) + constant
     bitHeaps.head.addPositiveConstant(complement)
     validLength
   }
@@ -45,15 +44,18 @@ case class BitHeapGroup[T](bitHeaps: ArrayBuffer[BitHeap[T]]) {
 
     // FIXME: consider the case when current stage solution contains more no pipeline
     while (currentTime < timeAndHeaps.keys.max) {
-      currentHeap.implStageHard(stageSolutions.remove(0))
-      timeAndHeaps.get(currentTime + 1) match {
-        case Some(heapNext) =>
-          heapNext.absorbHeapFrom(currentHeap.dSoft())
-          currentHeap = heapNext
-        case None =>
-          currentHeap = currentHeap.dSoft()
+      val currentStageSolution = stageSolutions.remove(0)
+      currentHeap.implStageHard(currentStageSolution)
+      if (currentStageSolution.pipelined) {
+        timeAndHeaps.get(currentTime + 1) match {
+          case Some(heapNext) =>
+            heapNext.absorbHeapFrom(currentHeap.dSoft())
+            currentHeap = heapNext
+          case None =>
+            currentHeap = currentHeap.dSoft()
+        }
+        currentTime += 1
       }
-      currentTime += 1
     }
 
     currentHeap.implAllHard(CompressorFullSolution(stageSolutions))
@@ -63,7 +65,7 @@ case class BitHeapGroup[T](bitHeaps: ArrayBuffer[BitHeap[T]]) {
 object BitHeapGroup {
 
   /** for merge arithmetic
-   */
+    */
   def fromUInts(weightedUInts: Seq[WeightedUInt]): BitHeapGroup[Bool] = {
     val bitHeaps = ArrayBuffer[BitHeap[Bool]]()
     weightedUInts.groupBy(_.arithInfo.time).foreach { case (_, weightedUInts) =>

--- a/src/main/scala/Chainsaw/arithmetic/bitheap/BitHeapSolver.scala
+++ b/src/main/scala/Chainsaw/arithmetic/bitheap/BitHeapSolver.scala
@@ -1,33 +1,38 @@
 package Chainsaw.arithmetic.bitheap
 
 import Chainsaw.arithmetic.{Compressor3to1, Compressor6to3}
-import Chainsaw.{logger, verbose}
+import Chainsaw._
 import Chainsaw.arithmetic._
 
+import scala.math._
 import scala.collection.mutable.ArrayBuffer
 
 abstract class BitHeapSolver {
 
+  def solverName = className(this)
+
   /** core method which must be kept
-   */
+    */
   def solveAll(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution = {
 
     val timeAndHeaps: Map[Int, BitHeap[BigInt]] = bitHeapGroup.bitHeaps.groupBy(_.time).map(pair => pair._1 -> pair._2.head)
-    val stages = ArrayBuffer[CompressorStageSolution]()
+    val stages                                  = ArrayBuffer[CompressorStageSolution]()
 
     var currentTime = timeAndHeaps.keys.min
     var currentHeap = timeAndHeaps(currentTime)
 
     while (currentTime < timeAndHeaps.keys.max) {
       stages += solveStage(currentHeap)
-      timeAndHeaps.get(currentTime + 1) match {
-        case Some(heapNext) =>
-          heapNext.absorbHeapFrom(currentHeap.dSoft())
-          currentHeap = heapNext
-        case None =>
-          currentHeap = currentHeap.dSoft()
+      if (stages.last.pipelined) {
+        timeAndHeaps.get(currentTime + 1) match {
+          case Some(heapNext) =>
+            heapNext.absorbHeapFrom(currentHeap.dSoft())
+            currentHeap = heapNext
+          case None =>
+            currentHeap = currentHeap.dSoft()
+        }
+        currentTime += 1
       }
-      currentTime += 1
     }
 
     val restSolution = solveAll(currentHeap)
@@ -48,6 +53,10 @@ abstract class BitHeapSolver {
 
 object NaiveSolver extends BitHeapSolver {
 
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution = solveAll(bitHeapGroup)
+
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(bitHeap)
+
   override def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = {
 
     import bitHeap._
@@ -57,17 +66,16 @@ object NaiveSolver extends BitHeapSolver {
     def solveStep: CompressorStepSolution = {
       if (!isLastStage) {
         val columnIdx = heap.indexWhere(_.nonEmpty)
-        val endIdx = heap.lastIndexWhere(_.nonEmpty)
-        val width = ((endIdx - columnIdx + 1) min cpaWidthMax) max 8
+        val endIdx    = heap.lastIndexWhere(_.nonEmpty)
+        val width     = ((endIdx - columnIdx + 1) min cpaWidthMax) max 8
         CompressorStepSolution(compressorName = "Compressor3to1", width, columnIdx, getExactScores(Compressor3to1(width), columnIdx, shouldPipeline = true))
-      }
-      else {
+      } else {
         val columnIdx = heap.indexWhere(_.nonEmpty)
         CompressorStepSolution(compressorName = "Compressor6to3", width, columnIdx, getExactScores(Compressor6to3, columnIdx, shouldPipeline = true))
       }
     }
 
-    val steps = ArrayBuffer[CompressorStepSolution]()
+    val steps    = ArrayBuffer[CompressorStepSolution]()
     val heapOuts = ArrayBuffer[BitHeap[BigInt]]()
     while (nonEmpty) {
       val stepSolution = solveStep
@@ -77,7 +85,102 @@ object NaiveSolver extends BitHeapSolver {
     val heapNext: BitHeap[BigInt] = heapOuts.reduce(_ + _)
     asSoft.absorbHeapFrom(heapNext)
     if (verbose >= 1) logger.info(s"----------------\n$this----------------\n")
-    CompressorStageSolution(steps, pipelined = true)
+    CompressorStageSolution(steps, heightMax, pipelined = true)
   }
 }
 
+object GreedSolver extends BitHeapSolver {
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution = solveAll(bitHeapGroup)
+
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(bitHeap)
+
+  override def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = {
+
+    import bitHeap._
+    def solveStep: CompressorStepSolution = {
+      val columnIndex             = heights.indexWhere(_ == heightMax)
+      var bestCompressor          = getCompressor("Compressor1to1", 1)
+      var bestReductionEfficiency = bestCompressor.reductionEfficiency()
+      var bestHeightReduction     = bestCompressor.heightReduction
+
+      val candidates = candidateCompressors.sortBy(compressor => compressor.reductionEfficiency()).reverse
+
+      candidates.foreach {
+        case gpc: Gpc =>
+          val exactScores = getExactScores(gpc, columnIndex, shouldPipeline = true)
+          if (exactScores.reductionEfficiency >= bestReductionEfficiency) {
+            if (exactScores.reductionEfficiency == bestReductionEfficiency) {
+              if (exactScores.heightReduction >= bestHeightReduction) {
+                bestReductionEfficiency = exactScores.reductionEfficiency
+                bestCompressor          = gpc
+                bestHeightReduction     = exactScores.heightReduction
+              }
+            } else {
+              bestReductionEfficiency = exactScores.reductionEfficiency
+              bestCompressor          = gpc
+              bestHeightReduction     = exactScores.heightReduction
+            }
+          }
+        case rowAdder: RowAdder =>
+          val searchWidthMax = rowAdder.widthMax min (bitHeap.width - columnIndex)
+          if (searchWidthMax >= rowAdder.widthMin) {
+            var searchWidth = searchWidthMax
+            while (searchWidth >= rowAdder.widthMin) {
+              val searchedRowAdder = getCompressor(rowAdder.name.firstBeforeChar('_'), searchWidth)
+              val exactScores      = getExactScores(searchedRowAdder, columnIndex, shouldPipeline = true)
+              if (exactScores.reductionEfficiency >= (bestReductionEfficiency max 1.0)) {
+                if (exactScores.reductionEfficiency == bestReductionEfficiency) {
+                  if (exactScores.heightReduction >= bestHeightReduction) {
+                    bestReductionEfficiency = exactScores.reductionEfficiency
+                    bestCompressor          = searchedRowAdder
+                    bestHeightReduction     = exactScores.heightReduction
+                  }
+                } else {
+                  bestReductionEfficiency = exactScores.reductionEfficiency
+                  bestCompressor          = searchedRowAdder
+                  bestHeightReduction     = exactScores.heightReduction
+                }
+              }
+
+              if ((exactScores.reductionEfficiency + 0.2) < 1.0) {
+                searchWidth = 8 * floor((searchWidth - 1) / 8).toInt
+              } else
+                searchWidth -= 1
+            }
+          }
+      }
+      bestCompressor match {
+        case gpc: Gpc           => CompressorStepSolution(gpc.name, -1, columnIndex, getExactScores(gpc, columnIndex, shouldPipeline = true))
+        case rowAdder: RowAdder => CompressorStepSolution(rowAdder.name.firstBeforeChar('_'), rowAdder.width, columnIndex, getExactScores(rowAdder, columnIndex, shouldPipeline = true))
+      }
+    }
+
+    val steps    = ArrayBuffer[CompressorStepSolution]()
+    val heapOuts = ArrayBuffer[BitHeap[BigInt]]()
+    while (nonEmpty) {
+      val stepSolution = solveStep
+      steps += stepSolution
+      heapOuts += implStepSoft(stepSolution)
+    }
+    val heapNext: BitHeap[BigInt] = heapOuts.reduce(_ + _)
+    asSoft.absorbHeapFrom(heapNext)
+    if (verbose >= 1) logger.info(s"----------------\n$this----------------\n")
+    CompressorStageSolution(steps, heightMax, pipelined = true)
+  }
+}
+
+object TailOptimizedSlover extends BitHeapSolver {
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution = solveAll(bitHeapGroup)
+
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(bitHeap)
+
+  override def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = ???
+}
+
+object TailAndHeightOptimizedSlover extends BitHeapSolver {
+  def apply(bitHeapGroup: BitHeapGroup[BigInt]): CompressorFullSolution = solveAll(bitHeapGroup)
+
+  def apply(bitHeap: BitHeap[BigInt]): CompressorFullSolution = solveAll(bitHeap)
+
+  override def solveStage(bitHeap: BitHeap[BigInt]): CompressorStageSolution = ???
+}

--- a/src/main/scala/Chainsaw/arithmetic/bitheap/CompressorSolution.scala
+++ b/src/main/scala/Chainsaw/arithmetic/bitheap/CompressorSolution.scala
@@ -1,14 +1,14 @@
 package Chainsaw.arithmetic.bitheap
 
 import Chainsaw._
-import Chainsaw.arithmetic._
+import Chainsaw.arithmetic.bitheap
 
 import java.io._
 
 case class CompressorScores(bitReduction: Int, heightReduction: Int, reductionEfficiency: Double, reductionRatio: Double) {
 
   /** compare two compressor according to current strategy
-   */
+    */
   def >(that: CompressorScores)(implicit strategy: CompressionStrategy): Boolean = {
 
     val br = this.bitReduction compare that.bitReduction
@@ -19,8 +19,8 @@ case class CompressorScores(bitReduction: Int, heightReduction: Int, reductionEf
     def det(compared: Seq[Int]) = compared.reverse.zipWithIndex.map { case (bit, weight) => bit << weight }.sum > 0
 
     val priority = strategy match {
-      case EfficiencyFirst => Seq(re, hr, br, rr)
-      case ReductionFirst => Seq(hr, re, br, rr)
+      case ReFirst => Seq(re, hr, br, rr)
+      case HrFirst => Seq(hr, re, br, rr)
     }
     det(priority)
   }
@@ -31,10 +31,11 @@ case class CompressorScores(bitReduction: Int, heightReduction: Int, reductionEf
 }
 
 @SerialVersionUID(42L)
-case class CompressorFullSolution(stageSolutions: Seq[CompressorStageSolution])
-  extends Serializable with HardAlgo {
+case class CompressorFullSolution(stageSolutions: Seq[CompressorStageSolution]) extends Serializable with HardAlgo {
 
   def latency() = stageSolutions.count(_.pipelined)
+
+  def outHeight = if (stageSolutions.last.stageHeight == -1) 3 else stageSolutions.last.stageHeight
 
   override def vivadoUtilEstimation = stageSolutions.map(_.vivadoUtilEstimation).reduce(_ + _)
 
@@ -54,7 +55,7 @@ object CompressorFullSolution {
   }
 }
 
-case class CompressorStageSolution(compressorSolutions: Seq[CompressorStepSolution], pipelined: Boolean) {
+case class CompressorStageSolution(compressorSolutions: Seq[CompressorStepSolution], stageHeight: Int, pipelined: Boolean) {
 
   def vivadoUtilEstimation = compressorSolutions.map(_.vivadoUtilEstimation).reduce(_ + _)
 

--- a/src/main/scala/Chainsaw/arithmetic/bitheap/package.scala
+++ b/src/main/scala/Chainsaw/arithmetic/bitheap/package.scala
@@ -1,18 +1,23 @@
 package Chainsaw.arithmetic
 
+import Chainsaw.StringUtil
+
 import scala.collection.mutable.ArrayBuffer
 
 package object bitheap {
 
-  def getCompressor(compressorName: String, width: Int) =
+  val candidateCompressors = RowAdders() ++ Gpcs()
+
+  def getCompressor(compressorName: String, width: Int = -1): CompressorGenerator = {
     compressorName match {
+      case "Compressor1to1" => Compressor1to1(width)
       case "Compressor2117" => Compressor2117
+      case "Compressor3to2" => Compressor3to2
       case "Compressor6to3" => Compressor6to3
       case "Compressor3to1" => Compressor3to1(width)
-
+      case "Compressor4to2" => Compressor4to2(width)
 
       // TODO: fill up the rest
     }
-
-
+  }
 }

--- a/src/test/scala/Chainsaw/arithmetic/bitheap/BitHeapSolverTest.scala
+++ b/src/test/scala/Chainsaw/arithmetic/bitheap/BitHeapSolverTest.scala
@@ -6,17 +6,18 @@ import Chainsaw.arithmetic._
 class BitHeapSolverTest extends ChainsawFlatSpec {
 
   /** --------
-   * 1. testCases
-   -------- */
+    *   1. testCases
+    * --------
+    */
   val testCases: Seq[Seq[ArithInfo]] = Seq(
-    Seq.fill(9)(ArithInfo(200, 0)) ++ Seq.fill(9)(ArithInfo(200, 0, time = 1)), // positive, diff time
-    Seq.fill(9)(ArithInfo(200, 0)) ++ Seq.fill(9)(ArithInfo(200, 0, isPositive = false)), // mixed, same time
-    Seq.fill(9)(ArithInfo(200, 0)) ++ Seq.fill(9)(ArithInfo(200, 0, isPositive = false, time = 1)), // mixed, diff time
+    Seq.fill(9)(ArithInfo(200, 0)) ++ Seq.fill(9)(ArithInfo(200, 0, time = 1)),                    // positive, diff time
+    Seq.fill(9)(ArithInfo(200, 0)) ++ Seq.fill(9)(ArithInfo(200, 0, isPositive = false)),          // mixed, same time
+    Seq.fill(9)(ArithInfo(200, 0)) ++ Seq.fill(9)(ArithInfo(200, 0, isPositive = false, time = 1)) // mixed, diff time
   )
 
-  /** --------
-   * 2. solver tester function
-   -------- */
+  /** -------- 2. solver tester function
+    * --------
+    */
   def testNaiveSolver(): Unit = {
     testCases.foreach(testCase => {
       val gen = BitHeapCompressor(testCase, NaiveSolver)
@@ -24,18 +25,20 @@ class BitHeapSolverTest extends ChainsawFlatSpec {
     })
   }
 
-  def testSolver(solverUnderTest:BitHeapSolver): Unit = {
+  def testSolver(solverUnderTest: BitHeapSolver): Unit = {
     testCases.foreach(testCase => {
       val gen = BitHeapCompressor(testCase, solverUnderTest)
       testOperator(gen, generatorConfigTable("BitHeapCompressor"))
     })
   }
 
+  def testGreedSolver() = testSolver(GreedSolver)
+
   override def generatorConfigTable = Map(
-    "BitHeapCompressor" -> TestConfig(full = true, naive = false, synth = false, impl = false),
+    "BitHeapCompressor" -> TestConfig(full = true, naive = false, synth = false, impl = false)
   )
 
   testNaiveSolver()
-
+  testGreedSolver()
 
 }

--- a/src/test/scala/Chainsaw/arithmetic/bitheap/BitHeapTests.scala
+++ b/src/test/scala/Chainsaw/arithmetic/bitheap/BitHeapTests.scala
@@ -30,12 +30,15 @@ class BitHeapTests extends ChainsawFlatSpec {
   it should "work" in {
     (0 until 1000).foreach { _ =>
       val weightedBigInts = getRandomOperands
-      val bitHeap = BitHeap.fromBigInts(weightedBigInts)
-      val expected = weightedBigInts.map(_.eval).sum
-      val actual = bitHeap.evalBigInt
-      assert(actual == expected, s"\noperands:\n${weightedBigInts.mkString("\n")}\n " +
-        s"heap:\n${bitHeap.heights.mkString(" ")}, weight = ${bitHeap.weightLow}\n " +
-        s"expected = $expected, actual = $actual")
+      val bitHeap         = BitHeap.fromBigInts(weightedBigInts)
+      val expected        = weightedBigInts.map(_.eval).sum
+      val actual          = bitHeap.evalBigInt
+      assert(
+        actual == expected,
+        s"\noperands:\n${weightedBigInts.mkString("\n")}\n " +
+          s"heap:\n${bitHeap.heights.mkString(" ")}, weight = ${bitHeap.weightLow}\n " +
+          s"expected = $expected, actual = $actual"
+      )
     }
   }
 
@@ -43,23 +46,23 @@ class BitHeapTests extends ChainsawFlatSpec {
 
   it should "contributeHeapTo" in {
     (0 until 1000).foreach { _ =>
-      val bitHeap0 = getRandomBitHeap
-      val bitHeap1 = getRandomBitHeap
+      val bitHeap0   = getRandomBitHeap
+      val bitHeap1   = getRandomBitHeap
       val sumsBefore = bitHeap0.evalBigInt + bitHeap1.evalBigInt
       bitHeap0.contributeHeapTo(bitHeap1)
       val sumsAfter = bitHeap0.evalBigInt + bitHeap1.evalBigInt
-      assert(bitHeap0.evalBigInt == 0) // bitHeap0 should be empty after move
+      assert(bitHeap0.evalBigInt == 0)                                           // bitHeap0 should be empty after move
       assert(sumsBefore == sumsAfter, s"before: $sumsBefore, after: $sumsAfter") // sums should be the same, before and after
     }
   }
 
   it should "addition" in {
     (0 until 1000).foreach { _ =>
-      val bitHeap0 = getRandomBitHeap
-      val bitHeap1 = getRandomBitHeap
+      val bitHeap0     = getRandomBitHeap
+      val bitHeap1     = getRandomBitHeap
       val valueBefore0 = bitHeap0.evalBigInt
-      val sumHeap = bitHeap0 + bitHeap1
-      val valueAfter0 = bitHeap0.evalBigInt
+      val sumHeap      = bitHeap0 + bitHeap1
+      val valueAfter0  = bitHeap0.evalBigInt
       assert(valueBefore0 == valueAfter0)
       assert(sumHeap.evalBigInt == bitHeap0.evalBigInt + bitHeap1.evalBigInt)
     }
@@ -68,18 +71,18 @@ class BitHeapTests extends ChainsawFlatSpec {
   it should "getSubHeap" in {
     (0 until 1000).foreach { _ =>
       val bitHeap = getRandomBitHeap
-      val small = BitHeap.fromHeights(Compressor2117.inputFormat, bitHeap.weightLow, bitHeap.time)
+      val small   = BitHeap.fromHeights(Compressor2117.inputFormat, bitHeap.weightLow, bitHeap.time)
       bitHeap.absorbHeapFrom(small)
       val valueBefore = bitHeap.evalBigInt
-      val sub = bitHeap.getSub(Compressor2117.inputFormat, 0)
-      val valueAfter = sub.evalBigInt + bitHeap.evalBigInt
+      val sub         = bitHeap.getSub(Compressor2117.inputFormat, 0)
+      val valueAfter  = sub.evalBigInt + bitHeap.evalBigInt
       assert(valueBefore == valueAfter)
     }
   }
 
   it should "allocate" in {
     (0 until 1000).foreach { _ =>
-      val bitHeap = getRandomBitHeap
+      val bitHeap     = getRandomBitHeap
       val randomValue = Random.nextInt((bitHeap.maxValue >> bitHeap.weightLow).toInt) << bitHeap.weightLow
       bitHeap.allocate(randomValue)
       assert(bitHeap.evalBigInt == randomValue)
@@ -89,35 +92,41 @@ class BitHeapTests extends ChainsawFlatSpec {
   it should "constant addition" in {
     (0 until 1000).foreach { _ =>
       // TODO: more bitheap and compressors of different shapes
-      val bitHeap = BitHeap.fromHeights(Seq.fill(10)(10), 0, 0)
+      val bitHeap     = BitHeap.fromHeights(Seq.fill(10)(10), 0, 0)
       val valueBefore = bitHeap.evalBigInt
-      val constant0 = BigInt(20, Random)
+      val constant0   = BigInt(20, Random)
       bitHeap.addPositiveConstant(constant0)
       val valueAfterAdd = bitHeap.evalBigInt
       //      println(s"valueBefore = $valueBefore, valueAfter = $valueAfterAdd, constant = $constant0")
       assert(valueAfterAdd == valueBefore + constant0)
-      val constant1 = Random.nextInt(bitHeap.maxValue.toInt)
-      val validLength = bitHeap.addNegativeConstant(-constant1)
+      val constant1     = Random.nextInt(bitHeap.maxValue.toInt)
+      val validLength   = bitHeap.addNegativeConstant(-constant1)
       val valueAfterSub = bitHeap.evalBigInt
-      val golden = valueAfterAdd - constant1
+      val golden        = valueAfterAdd - constant1
       //      println(s"valueAfterAdd = $valueAfterAdd, valueAfterSub = $valueAfterSub, golden = $golden, constant = $constant1")
       if (golden >= 0) assert(valueAfterSub.mod(Pow2(validLength)) == golden.mod(Pow2(validLength)))
     }
   }
 
-  val solution200_6 = CompressorFullSolution(Seq(
-    CompressorStageSolution((0 until 200).map(i => CompressorStepSolution(
-      compressorName = "Compressor6to3", width = 1, columnIndex = i, compressorScores = CompressorScores(0, 0, 0, 0))), pipelined = true),
-    CompressorStageSolution((0 until 2).map(i => CompressorStepSolution("Compressor3to1", 96, 96 * i, CompressorScores(0, 0, 0, 0))), pipelined = true)))
+  val solution200_6 = CompressorFullSolution(
+    Seq(
+      CompressorStageSolution(
+        (0 until 200).map(i => CompressorStepSolution(compressorName = "Compressor6to3", width = 1, columnIndex = i, compressorScores = CompressorScores(0, 0, 0, 0))),
+        -1,
+        pipelined = true
+      ),
+      CompressorStageSolution((0 until 2).map(i => CompressorStepSolution("Compressor3to1", 96, 96 * i, CompressorScores(0, 0, 0, 0))), -1, pipelined = true)
+    )
+  )
 
   behavior of "implSoft"
 
   it should "work on a stage" in {
     (0 until 1000).foreach { _ =>
       // TODO: more bitheap and compressors of different shapes
-      val bitHeap = BitHeap.fromHeights(Seq.fill(10)(10), 0, 0)
-      val steps = Seq(0, 2, 4, 6).map(CompressorStepSolution("Compressor2117", 1, _, CompressorScores(0, 0, 0, 0)))
-      val solution = CompressorStageSolution(steps, pipelined = true)
+      val bitHeap     = BitHeap.fromHeights(Seq.fill(10)(10), 0, 0)
+      val steps       = Seq(0, 2, 4, 6).map(CompressorStepSolution("Compressor2117", 1, _, CompressorScores(0, 0, 0, 0)))
+      val solution    = CompressorStageSolution(steps, -1, pipelined = true)
       val valueBefore = bitHeap.evalBigInt
       bitHeap.implStageSoft(solution)
       val valueAfter = bitHeap.evalBigInt
@@ -129,10 +138,10 @@ class BitHeapTests extends ChainsawFlatSpec {
   it should "work on the whole heap" in {
     (0 until 1000).foreach { _ =>
       // TODO: more bitheap and compressors of different shapes
-      val bitHeap = BitHeap.fromHeights(Seq.fill(200)(6), 0, 0)
+      val bitHeap     = BitHeap.fromHeights(Seq.fill(200)(6), 0, 0)
       val valueBefore = bitHeap.evalBigInt
       val bitHeapNext = bitHeap.implAllSoft(solution200_6)
-      val valueAfter = bitHeapNext.evalBigInt
+      val valueAfter  = bitHeapNext.evalBigInt
       assert(valueBefore == valueAfter)
     }
   }
@@ -142,7 +151,7 @@ class BitHeapTests extends ChainsawFlatSpec {
   // TODO: more bitheap and solutions of different shapes
   it should "work on the whole heap" in {
     case class Add200_6() extends Component {
-      val dataIn = in Vec(UInt(200 bits), 6)
+      val dataIn  = in Vec (UInt(200 bits), 6)
       val bitHeap = BitHeap.fromUInts(dataIn.map(WeightedUInt(_, ArithInfo(200, 0))))
       val dataOut = bitHeap.implAllHard(solution200_6).toUInts
       dataOut.foreach(out(_))
@@ -151,7 +160,7 @@ class BitHeapTests extends ChainsawFlatSpec {
     SpinalConfig().generateVerilog(Add200_6())
     // sim
     SimConfig.withFstWave.compile(Add200_6()).doSim { dut =>
-      val data = Seq.fill(6)(BigInt(200, Random))
+      val data    = Seq.fill(6)(BigInt(200, Random))
       val valueIn = data.sum
       dut.clockDomain.forkStimulus(2)
       dut.clockDomain.waitSampling()
@@ -170,20 +179,30 @@ class BitHeapTests extends ChainsawFlatSpec {
   behavior of "CompressorFullSolution"
 
   it should "(de)serialization" in {
-    val solution: CompressorFullSolution = CompressorFullSolution(Seq(
-      CompressorStageSolution(Seq(
-        CompressorStepSolution("Compressor2117", 1, 0, CompressorScores(0, 0, 0, 0)),
-        CompressorStepSolution("Compressor2117", 1, 2, CompressorScores(0, 0, 0, 0)),
-        CompressorStepSolution("Compressor2117", 1, 4, CompressorScores(0, 0, 0, 0)),
-        CompressorStepSolution("Compressor2117", 1, 6, CompressorScores(0, 0, 0, 0))
-      ), pipelined = true),
-      CompressorStageSolution(Seq(
-        CompressorStepSolution("Compressor2117", 1, 0, CompressorScores(0, 0, 0, 0)),
-        CompressorStepSolution("Compressor2117", 1, 2, CompressorScores(0, 0, 0, 0)),
-        CompressorStepSolution("Compressor2117", 1, 4, CompressorScores(0, 0, 0, 0)),
-        CompressorStepSolution("Compressor2117", 1, 6, CompressorScores(0, 0, 0, 0))
-      ), pipelined = true)
-    ))
+    val solution: CompressorFullSolution = CompressorFullSolution(
+      Seq(
+        CompressorStageSolution(
+          Seq(
+            CompressorStepSolution("Compressor2117", 1, 0, CompressorScores(0, 0, 0, 0)),
+            CompressorStepSolution("Compressor2117", 1, 2, CompressorScores(0, 0, 0, 0)),
+            CompressorStepSolution("Compressor2117", 1, 4, CompressorScores(0, 0, 0, 0)),
+            CompressorStepSolution("Compressor2117", 1, 6, CompressorScores(0, 0, 0, 0))
+          ),
+          -1,
+          pipelined = true
+        ),
+        CompressorStageSolution(
+          Seq(
+            CompressorStepSolution("Compressor2117", 1, 0, CompressorScores(0, 0, 0, 0)),
+            CompressorStepSolution("Compressor2117", 1, 2, CompressorScores(0, 0, 0, 0)),
+            CompressorStepSolution("Compressor2117", 1, 4, CompressorScores(0, 0, 0, 0)),
+            CompressorStepSolution("Compressor2117", 1, 6, CompressorScores(0, 0, 0, 0))
+          ),
+          -1,
+          pipelined = true
+        )
+      )
+    )
 
     val file = new File("solution")
     solution.save(file)


### PR DESCRIPTION
…ap time consistency with Software Heap

[BitHeapCompressor.scala]: adjust outputType inference according to solution
[BitHeapGroup.scala]: adjust the pipeline method in implAllHard according to solution
[BitHeapSolver.scala]: 1) add solverName attribute for BitHeapSolver to avoid testName overlap; 2) add GreedSolver and some Solver waiting for implementation
[BitHeapSolverTest.scala]: 1) change and add GreedSolver test according to BitHeapSolver's change
[BitHeapTests.scala]: add stageHeight parameter for CompressorStageSolution define because this push add a stageHeight attribute for outputPortWidth inference
[BmAlgo.scala]: change WeightedValue to WeightedBigInt
[ChainsawBaseGenerator.scala]: move the trait position of some type ChainsawBaseGenerator definition
[CompressorSolution.scala]: add stageHeight attribute for CompressorStageSolution
[Enums.scala]: rename two Strategy's trait name
[Gpcs.scala]: Comment out some compressors because getCompressor is not fully implemented
[bitheap.package.scala]: add candidateCompressors for BitHeap as available compressor
[Chainsaw.package.scala]: add a firstBeforeChar method in StringUtil
[RowAdder.scala]: change RowAdders's apply method return type